### PR TITLE
Support limited file recognization

### DIFF
--- a/lib/see_as_vee/helpers.rb
+++ b/lib/see_as_vee/helpers.rb
@@ -29,7 +29,7 @@ module SeeAsVee
 
     module Privates
       FILE_TYPE = {
-        /\A(Microsoft OOXML)/ => :xlsx,
+        /\A(Microsoft OOXML|Zip archive data)/ => :xlsx,
         /\A(UTF-8 Unicode|ASCII) text/ => :csv
       }.freeze
 


### PR DESCRIPTION
In some OSs or some versions of the `file` command line tool, Excel files are recognized as `Zip archive data, at least vN.N to extract`. When the files come as ActionDispatch::Http::UploadedFile then it has an uninteresting filename so the extension cannot be used anyways.

With this change, Office packaged files are recognized.