### PR TITLE
Switch abandoned `axlsx` to `caxlsx`

### DIFF
--- a/lib/see_as_vee/version.rb
+++ b/lib/see_as_vee/version.rb
@@ -1,3 +1,3 @@
 module SeeAsVee
-  VERSION = '0.6.3'.freeze
+  VERSION = '0.7.0-beta1'.freeze
 end

--- a/see_as_vee.gemspec
+++ b/see_as_vee.gemspec
@@ -30,10 +30,7 @@ Gem::Specification.new do |spec|
   # superclass mismatch for class Loader
   #
   spec.add_dependency 'simple_xlsx_reader', '~> 1.0.5'
-  # TODO: This gem not maintained anymore. Migration to `caxlsx` pending
-  spec.add_dependency 'axlsx'
-  spec.add_dependency 'zip-zip'
-  spec.add_dependency 'rubyzip', '~> 2.3.2'
+  spec.add_dependency 'caxlsx', '~> 3.4.1'
   # spec.add_dependency 'ruby-filemagic', require: false
 
   spec.add_development_dependency 'bundler', '> 2.3.0'


### PR DESCRIPTION
Switch abandoned `axlsx` to `caxlsx`

Roadmap:
- ~Fix file recognition. Patch version 0.6.3.~
- Switch abandoned `axlsx` to `caxlsx`. Bump 0.7.
- [Bump or remove dry gems](https://github.com/kantox/see_as_vee/pull/4). Bump 0.8.0
- [Fix ruby 2.7+](https://github.com/kantox/see_as_vee/pull/5). Bump 0.8.1

