### PR TITLE
Avoid conditionals in `gemspec` and relax version requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.3']
+        ruby-version: ['4.0']
         allow-failure: [false]
-        frozen-string: [false]
+        frozen-string: [true]
         include:
+          - ruby-version: '3.4'
+            allow-failure: true
+            frozen-string: true
+          - ruby-version: '3.3'
+            allow-failure: true
+            frozen-string: true
           - ruby-version: '3.2'
             allow-failure: true
             frozen-string: true

--- a/lib/see_as_vee/version.rb
+++ b/lib/see_as_vee/version.rb
@@ -1,3 +1,3 @@
 module SeeAsVee
-  VERSION = '0.8.0'.freeze
+  VERSION = '0.8.1-beta1'.freeze
 end

--- a/see_as_vee.gemspec
+++ b/see_as_vee.gemspec
@@ -30,31 +30,21 @@ Gem::Specification.new do |spec|
   # superclass mismatch for class Loader
   #
   spec.add_dependency 'simple_xlsx_reader', '~> 1.0.5'
-  # TODO: This gem not maintained anymore. Migration to `caxlsx` pending
-  spec.add_dependency 'caxlsx', '~> 3.4.1'
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
-    spec.add_dependency 'ostruct'
-  end
-  spec.add_dependency 'rubyzip', '~> 2.4'
+
+  spec.add_dependency 'caxlsx', '>= 3.4.1'
+  spec.add_dependency 'ostruct'
+  spec.add_dependency 'rubyzip', '>= 2.3.2'
   # spec.add_dependency 'ruby-filemagic', require: false
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-    spec.add_dependency 'dry-validation', '~> 1.0'
-    spec.add_dependency 'dry-configurable', '~> 1.0'
-  else
-    spec.add_dependency 'dry-validation', '~> 0.13.3'
-    spec.add_dependency 'dry-configurable', '~> 0.11.6'
-  end
 
   spec.add_development_dependency 'bundler'
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
-    spec.add_development_dependency 'rake', '> 13.0'
-  else
-    spec.add_development_dependency 'rake', '> 10.0'
-  end
+  spec.add_development_dependency 'rake', '>= 10.5.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'awesome_print'
 
-  # spec.add_development_dependency 'codeclimate-test-reporter'
+  # optional runtime dependencies
+  spec.add_development_dependency 'dry-validation', '>= 0.10.7'
+  spec.add_development_dependency 'dry-configurable', '>= 0.7.0'
+
   # spec.add_development_dependency 'simplecov', '~> 0.12.0'
 end

--- a/see_as_vee.gemspec
+++ b/see_as_vee.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'caxlsx', '>= 3.4.1'
   spec.add_dependency 'ostruct'
+  spec.add_dependency 'csv'
   spec.add_dependency 'rubyzip', '>= 2.3.2'
   # spec.add_dependency 'ruby-filemagic', require: false
 

--- a/spec/see_as_vee_spec.rb
+++ b/spec/see_as_vee_spec.rb
@@ -145,13 +145,7 @@ describe SeeAsVee do
   end
 
   it "applies schema as checker" do
-    dry_class =
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-        Dry::Schema
-      else
-        Dry::Validation
-      end
-
+    dry_class = Dry::Schema
     m = %w[Params Form].detect(&dry_class.method(:respond_to?))
     expect(m).not_to be_nil
 


### PR DESCRIPTION

We discussed [here](https://github.com/am-kantox/see_as_vee/pull/16) how conditionals cause issues during gem build: 
Also strict pining gem versions may block usage.